### PR TITLE
Update GH actions version

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 


### PR DESCRIPTION
GitHub actions is currently using version 2. This caused a few deprecation warnings that I did not like, so we are now using version 4 of GH actions.